### PR TITLE
Case study page prototype (CS2 — Instana AI Strategy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ briefs/inspo/
 *.tsbuildinfo
 .vscode/
 .idea/
+.claude/

--- a/session_notes.md
+++ b/session_notes.md
@@ -4,6 +4,111 @@ This file is a running log of session handoffs. Read it at the start of a new ch
 
 ---
 
+## 2026-04-28 — Case Study Page Prototype (CS2 — Instana AI Strategy)
+**Branch:** `dev`
+
+### What Happened
+
+Built a hardcoded case study page prototype at `/ux/work/instana-ai-strategy` to nail the design language for UX work pages before porting to Sanity. CS2 (Instana AI Strategy) writeup used as the example content.
+
+#### Files Added
+- `site/src/app/ux/work/instana-ai-strategy/page.tsx` — full hardcoded page
+- `site/src/app/ux/work/instana-ai-strategy/page.module.css` — narrative case-study layout
+- `site/src/components/ux/work/Figure.tsx` — placeholder asset component (kinds: screenshot/diagram/matrix/flow/hero/multi)
+- `site/src/components/ux/work/Figure.module.css`
+
+#### Design Patterns Established
+- **Hero**: title + tagline + meta stacked left (cols 1–7) with `justify-content: space-between` for vertical drama. Image right (cols 8–13) full hero height. Title at `var(--text-hero)`. Back arrow `←` only (no "Work" text), replaces eyebrow.
+- **Section labels**: bumped to `text-xl` mixed-case heading style. Subsection labels stay as small uppercase tags.
+- **Section variants**:
+  - `.grid` + `.bodyTwoCol` — short sections (Thesis, §2 The realization). Label cols 1–5, prose cols 5–13 in 2 sub-columns via `column-count: 2`.
+  - `.grid` + `.gridAside` — section with side aside (figure or pull quote in cols 5–13).
+  - `.grid` + `.gridThirds` — title | text | image side by side (each 4 cols). Used in §1.
+  - `.gridFramework` + multiple `.frameworkBody` + `.fullVisual` siblings — multi-subsection sections (§3, §4, §5). Section title pinned cols 1–5; bodies auto-flow into rows in cols 5–13; full-width visuals break to cols 1–13.
+- **Tile grids**:
+  - 5-tile (taxonomy): `repeat(5, 1fr)`, vertical rules between tiles only, no wrapper rules.
+  - 2x2 (UI integration): short horizontal rule above each tile (width matched to body text, not full tile width).
+  - 3-tile (audience): demoted to em-dash bullet list inside body prose.
+- **Visuals**: in-band `.fullBleedFigure` lives inside `.frameworkBody` (cols 5–13). `.fullVisual` is sibling of `.frameworkBody` (breaks to cols 1–13 — for flow climaxes only).
+- **Stat callout**: compact block with `text-3xl` value, `max-width: 440px`, single top rule. Sits as a `.frameworkBody` child, not a wide row.
+- **Line length**: `.body p` capped at `max-width: 60ch`. `.bodyColumns` for 2-col overflow flow (used in §5 prose).
+- **Layout integrity**: every wrapper uses `padding: 0 var(--gutter)` only — no `max-width: var(--max-w)` constraint at wrapper level (matches rest of site).
+
+#### Key Iteration Decisions
+- Started with section grid pattern, evolved through several layouts before settling
+- Pull quote moved from standalone block under §2 to sit beside thesis-style 2-col body
+- §1 went through gridSideImage → gridThirds (title | text | image)
+- §3 framework restructured to "sticky-left" pattern (title pinned, content stacks in right band)
+- §4 added the `.fullVisual` breakout for flow climaxes
+- §5 stat callout simplified from `text-5xl+` keynote moment → compact card
+
+#### Open Decisions (Pending User)
+- §1 layout settled on title | text | image thirds — could revisit if other case studies need wider images
+- Whether to apply same patterns to CS1, CS3, CS4, CS5 next or do schema port first
+
+### Still To Do
+- Port to Sanity: header fields stay structured, body becomes Portable Text with custom block types (`figure`, `pullQuote`, `statCallout`, em-dash list)
+- Apply same patterns to CS1, CS3, CS4, CS5 (will be faster now that the system is settled)
+- Replace placeholder `Figure` blocks with real assets per `Assets.md` in each case study folder
+- Memory saved at `project_case_study_page.md` so next session can pick up the patterns without re-deriving
+
+---
+
+## 2026-04-05 — Performance Audit + UX Page Swiss Redesign
+**Branch:** `dev`
+
+### What Happened
+
+#### Performance & Cleanup
+- Full site audit across CSS, components, bundle, and images
+- Deleted 3 unused public images (~6.3MB removed: 5247432265-R1-022-9A.jpg, andrew.jpg, placeholder-bar.jpeg)
+- Deleted unused `LogoOutline.tsx` component
+- Removed unused CSS: `.previewGrid` class, `--color-bg-mid` and `--color-bg-alt` variables
+- Cleaned placeholder reference in objects.ts
+
+#### Image Optimization
+- Created `SanityImage` client component (`src/lib/sanity-image.tsx`) — wraps next/image with custom Sanity CDN loader (Sanity handles resize/format, next/image handles lazy loading/srcset/layout shift)
+- Shopify images go through next/image directly via remotePatterns (Next.js optimizes)
+- Converted all `<img>` → `<Image>`/`<SanityImage>` on art detail, store detail, store grid, and Credentials
+- Updated next.config.ts: AVIF+WebP formats, Sanity CDN in remotePatterns, 1-year image cache TTL
+- Store grid uses `fill` mode with wrapper div for aspect-ratio control
+- Art + store detail use explicit width/height with CSS `height: auto`
+- Added `object-position: center` for Shopify images (no hotspot data available)
+- CartDrawer dynamically imported via `next/dynamic` (code-split from initial bundle)
+
+#### UX Page — Swiss-Inspired Redesign (Brockmann/Hofmann)
+- **Section labels** ("Work", "Thoughts") → `--text-4xl` light weight, cols 1–3 — architectural chapter headers
+- **Baseline alignment**: section label baseline locks to first item title via `align-items: first baseline` (scoped via `.layoutBaseline` class)
+- **Item layout**: title spans full row at `--text-2xl` light, summary + metadata share second row with `first baseline` alignment
+- **Item grid**: body cols 4–8, gap col 9, metadata cols 10–11 (company/role/year stacked for Work; type/year for Thoughts)
+- **Whole row clickable**: Link wraps entire item, hover fades row to 0.5 opacity. Removed underlined "View project →" / "Read →" links
+- **Sanity schema**: added `type` and `year` fields to thought.js (legacy `context` field hidden). Work uses separate `company`, `role`, `year` fields
+- **Credentials**: photo cols 1–6, pubs/talks cols 10–12, padding-top on pubCol for vertical centering
+- **Closing CTA**: title matches section headers (`--text-4xl` light, cols 1–3), links cols 4–7 at `--text-base`, LogoSolid cols 10–11 in `--color-text`
+
+#### Background Logo & Overscroll
+- Created `ScrollFadeLogo` client component — fades logo to 0 opacity over one viewport height of scroll
+- Fixed overscroll white bleed: `html:has([data-theme="ux"])` gets dark background
+
+#### Mobile
+- Work/Thoughts: 2-column layout (summary left, meta right)
+- Art/store detail: tightened image gap to 2px, matched peek pattern (max-height on first image)
+- Store detail images aligned with art page behavior
+
+### Design Decisions
+- All-medium weight (500) for body/label text — mixing regular+medium reads as inconsistency in Aktiv Grotesk
+- Light weight (300) reserved for display/title elements where scale contrast justifies it
+- Removed section divider rules between Work/Thoughts items — link underline was sufficient, now whole row is the interaction
+- `--sp-section` (48px) gap between section label and first item content
+
+### Still To Do
+- Populate Sanity thought `type` and `year` fields
+- Responsive fine-tuning on type sizes
+- Decide on closing CTA phrase ("End of file." / "Work continues." / "Onward." being considered)
+- Upload images to Sanity for Credentials section
+
+---
+
 ## 2026-04-04 — Studio Page Layout + Home Page Type Treatment
 **Branch:** `feature/studio-page-layout` → merged to `dev`
 

--- a/site/src/app/ux/work/instana-ai-strategy/page.module.css
+++ b/site/src/app/ux/work/instana-ai-strategy/page.module.css
@@ -1,0 +1,789 @@
+/* ─────────────────────────────────────────────────────
+   Project detail page — narrative case-study layout
+   12-column grid, no buffer cols. Mixed layouts:
+   full-bleed figures, tile grids, splits, prose blocks.
+───────────────────────────────────────────────────── */
+
+.page {
+  padding-top: var(--nav-h);
+  padding-bottom: var(--sp-20);
+}
+
+/* Back arrow — sits inline in hero where eyebrow used to live */
+.heroBack {
+  grid-column: 1 / 2;
+  grid-row: 1;
+  align-self: start;
+  font-size: var(--text-2xl);
+  font-weight: var(--font-medium);
+  color: var(--color-muted);
+  line-height: 1;
+  transition: color 0.15s;
+}
+
+.heroBack:hover {
+  color: var(--color-text);
+}
+
+/* ─────────────────────────────────────────────────────
+   HERO — above the fold
+   12-col grid, 3 row tracks: meta strip / title+image / lockup
+───────────────────────────────────────────────────── */
+.hero {
+  min-height: calc(100svh - var(--nav-h));
+  padding: var(--sp-xxl) var(--gutter) var(--sp-12);
+  border-bottom: 1px solid var(--color-rule);
+  display: flex;
+}
+
+.heroGrid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  grid-template-rows: auto 1fr;
+  column-gap: var(--col-gap);
+  row-gap: var(--sp-xl);
+  width: 100%;
+  min-height: calc(100svh - var(--nav-h) - var(--sp-xxl) - var(--sp-12));
+}
+
+.heroLockup {
+  grid-column: 1 / 8;
+  grid-row: 2;
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: var(--sp-section);
+}
+
+.heroTitleGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-xxxl);
+}
+
+.heroTitle {
+  font-size: var(--text-hero);
+  font-weight: var(--font-medium);
+  letter-spacing: var(--tracking-tighter);
+  line-height: var(--leading-tight);
+  color: var(--color-text);
+}
+
+.heroFigure {
+  grid-column: 8 / 13;
+  grid-row: 1 / 3;
+  align-self: stretch;
+  display: flex;
+}
+
+.heroFigure :global(figure) {
+  margin: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.heroSummary {
+  font-size: var(--text-xl);
+  font-weight: var(--font-medium);
+  line-height: var(--leading-snug);
+  color: var(--color-muted);
+  max-width: 44ch;
+}
+
+.heroMeta {
+  display: flex;
+  gap: var(--sp-xxl);
+  flex-wrap: wrap;
+  margin-top: var(--sp-md);
+}
+
+.heroMetaItem {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-xs);
+}
+
+.heroMetaItem dt {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-muted);
+  text-transform: uppercase;
+}
+
+.heroMetaItem dd {
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  color: var(--color-text);
+}
+
+/* ─────────────────────────────────────────────────────
+   Section structure — full 12 col, no edge buffer
+───────────────────────────────────────────────────── */
+.section {
+  border-top: 1px solid var(--color-rule);
+  padding: var(--sp-12) 0;
+}
+
+/* Section grid — label on row 1 (cols 1–4), body on row 2 spanning full 12 cols */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  grid-template-rows: auto auto;
+  row-gap: var(--sp-xl);
+  column-gap: var(--col-gap);
+  padding: 0 var(--gutter);
+}
+
+.label {
+  grid-column: 1 / 5;
+  grid-row: 1;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-muted);
+  text-transform: uppercase;
+}
+
+/* Main section headers — one step up from .label, mixed-case heading */
+.sectionTitle {
+  grid-column: 1 / 5;
+  grid-row: 1;
+  font-size: var(--text-xl);
+  font-weight: var(--font-medium);
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  color: var(--color-text);
+}
+
+.body {
+  grid-column: 1 / 13;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Side-image layout — label/body stacked left in cols 1–5,
+   image takes the right 8 cols spanning both stacked rows */
+.gridAside .label {
+  grid-column: 1 / 5;
+  grid-row: 1;
+}
+
+.gridAside .body {
+  grid-column: 1 / 5;
+  grid-row: 2;
+}
+
+.gridAside .body > p {
+  max-width: none;
+}
+
+.gridAside .figureCell,
+.gridAside .quoteCell {
+  grid-column: 5 / 13;
+  grid-row: 1 / 3;
+}
+
+.gridAside .figureCell :global(figure) {
+  margin: 0;
+}
+
+.gridAside .quoteCell {
+  display: flex;
+  align-items: center;
+}
+
+.gridAside .quoteCell p {
+  font-size: clamp(var(--text-3xl), 4.5vw, var(--text-5xl));
+  font-weight: var(--font-light);
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  color: var(--color-text);
+  max-width: 24ch;
+}
+
+.body > p {
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  line-height: var(--lh-lg);
+  color: var(--color-text);
+  max-width: 68ch;
+}
+
+.body > p + p {
+  margin-top: var(--sp-lg);
+}
+
+/* 1/3-2/3 layout: label cols 1–5, prose flows in right 8 cols split
+   as 2 sub-columns. Used by thesis + realization. */
+.bodyTwoCol {
+  grid-column: 5 / 13;
+  grid-row: 1;
+  column-count: 2;
+  column-gap: var(--col-gap);
+}
+
+.bodyTwoCol > p {
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  line-height: var(--lh-lg);
+  color: var(--color-text);
+  break-inside: avoid;
+}
+
+.bodyTwoCol > p + p {
+  margin-top: var(--sp-lg);
+}
+
+/* Three-column thirds layout: title | text | image (each spans 4 of 12) */
+.gridThirds .sectionTitle,
+.gridThirds .label {
+  grid-column: 1 / 5;
+  grid-row: 1;
+}
+
+.gridThirds .body {
+  grid-column: 5 / 9;
+  grid-row: 1;
+}
+
+.gridThirds .body > p {
+  max-width: none;
+}
+
+.gridThirds .figureCell {
+  grid-column: 9 / 13;
+  grid-row: 1;
+}
+
+.gridThirds .figureCell :global(figure) {
+  margin: 0;
+}
+
+/* Pull quote sitting under bodyTwoCol — cols 5–13, row 2 */
+.quoteUnder {
+  grid-column: 5 / 13;
+  grid-row: 2;
+  margin-top: var(--sp-xxl);
+}
+
+.quoteUnder p {
+  font-size: clamp(var(--text-3xl), 4.5vw, var(--text-5xl));
+  font-weight: var(--font-light);
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  color: var(--color-text);
+  max-width: 24ch;
+}
+
+.split2 {
+  grid-column: 1 / 13;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--sp-xl) var(--col-gap);
+}
+
+.split2 > p {
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  line-height: var(--lh-lg);
+  color: var(--color-text);
+}
+
+/* Subsection header — used by §4 (and any non-framework section) */
+.subSectionHeader {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  column-gap: var(--col-gap);
+  padding: var(--sp-section) var(--gutter) var(--sp-xl);
+  margin-top: var(--sp-xxl);
+}
+
+.subSectionHeader .label {
+  grid-column: 1 / 5;
+  grid-row: 1;
+}
+
+.subSectionHeader .subSectionLead {
+  grid-column: 5 / 13;
+  grid-row: 1;
+}
+
+/* Framework layout — section title pinned left in row 1.
+   Children at cols 5–13 (frameworkBody) and cols 1–13 (fullVisual)
+   auto-flow into successive rows. */
+.gridFramework {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  column-gap: var(--col-gap);
+  row-gap: var(--sp-section);
+  padding: 0 var(--gutter);
+}
+
+.gridFramework .sectionTitle {
+  grid-column: 1 / 5;
+  grid-row: 1;
+}
+
+.frameworkBody {
+  grid-column: 5 / 13;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-large-section);
+}
+
+/* Full-width visual that breaks out of the right band — cols 1–13 */
+.fullVisual {
+  grid-column: 1 / 13;
+}
+
+.fullVisual :global(figure) {
+  margin: 0;
+}
+
+.frameworkIntro {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-lg);
+}
+
+.frameworkIntro p {
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  line-height: var(--lh-lg);
+  color: var(--color-text);
+  max-width: 60ch;
+}
+
+.subSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-section);
+}
+
+.subSection > header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-md);
+}
+
+.subSection > header .label {
+  grid-column: auto;
+  grid-row: auto;
+}
+
+.subSectionLead {
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  line-height: var(--lh-lg);
+  color: var(--color-text);
+  max-width: 50ch;
+}
+
+.subSection .body {
+  grid-column: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.subSection .body > p {
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  line-height: var(--lh-lg);
+  color: var(--color-text);
+  max-width: 60ch;
+}
+
+.subSection .body > p + p {
+  margin-top: var(--sp-lg);
+}
+
+/* Em-dash bullet list — used inside body prose */
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-md);
+  padding-left: var(--sp-lg);
+  margin: var(--sp-md) 0;
+  list-style: none;
+}
+
+.list li {
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  line-height: var(--lh-lg);
+  color: var(--color-text);
+  position: relative;
+  max-width: 60ch;
+}
+
+.list li::before {
+  content: '—';
+  position: absolute;
+  left: calc(-1 * var(--sp-lg));
+  color: var(--color-muted);
+}
+
+.list em {
+  font-style: italic;
+  color: var(--color-text);
+}
+
+.subSection .body > .list + p {
+  margin-top: var(--sp-lg);
+}
+
+/* 2-column prose flow — for longer body blocks (e.g. §5) */
+.bodyColumns {
+  column-count: 2;
+  column-gap: var(--col-gap);
+}
+
+.bodyColumns > p {
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  line-height: var(--lh-lg);
+  color: var(--color-text);
+  break-inside: avoid;
+}
+
+.bodyColumns > p + p {
+  margin-top: var(--sp-lg);
+}
+
+/* Stat callout + body side by side — stat takes its natural width,
+   prose fills the rest */
+.statRow {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--sp-section);
+  align-items: start;
+}
+
+/* Override .body's grid-column inheritance when nested in statRow */
+.statRow .body,
+.statRow .statCallout {
+  grid-column: auto;
+  grid-row: auto;
+}
+
+/* Inside frameworkBody, content blocks don't double-up on gutter padding.
+   The frameworkBody already lives inside the page gutter via .gridFramework. */
+.frameworkBody .tileGrid5,
+.frameworkBody .tileGrid2x2,
+.frameworkBody .tileGrid3,
+.frameworkBody .fullBleedFigure,
+.frameworkBody .splitGrid,
+.frameworkBody .grid {
+  padding-left: 0;
+  padding-right: 0;
+  margin: 0;
+}
+
+/* ─────────────────────────────────────────────────────
+   Tile grids — taxonomy, UI integration models, audience
+───────────────────────────────────────────────────── */
+.tileGrid2x2,
+.tileGrid3 {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  column-gap: var(--col-gap);
+  row-gap: 0;
+  padding: var(--sp-xl) var(--gutter) var(--sp-section);
+}
+
+/* 5-tile taxonomy: even 5-col split, no wrapper rules — vertical
+   separators between tiles do the work. */
+.tileGrid5 {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  column-gap: var(--col-gap);
+  padding: var(--sp-xl) 0 var(--sp-section);
+}
+
+/* 2x2 grid: each tile spans 6 cols */
+.tileGrid2x2 .tile {
+  grid-column: span 6;
+}
+
+/* 3-tile grid: each tile spans 4 cols */
+.tileGrid3 .tile {
+  grid-column: span 4;
+}
+
+.tile {
+  padding: var(--sp-xl) var(--sp-md) var(--sp-xl) 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-sm);
+  border-right: 1px solid var(--color-rule);
+  position: relative;
+}
+
+/* Narrower tiles in the 5-up taxonomy get tighter type */
+.tileGrid5 .tile {
+  padding-right: var(--sp-md);
+}
+
+.tileGrid5 .tileTitle {
+  font-size: var(--text-base);
+}
+
+.tileGrid5 .tileBody {
+  font-size: var(--text-sm);
+  line-height: var(--lh-sm);
+  max-width: none;
+}
+
+/* Remove right rule from end-of-row tiles in 5-tile and 3-tile grids */
+.tileGrid5 .tile:nth-child(5),
+.tileGrid3 .tile:nth-child(3n) {
+  border-right: none;
+  padding-right: 0;
+}
+
+/* 2x2 grid uses a short horizontal rule above each tile, matched to
+   the tile body text column width (not the full tile width). */
+.tileGrid2x2 .tile {
+  border-right: none;
+  padding: 0 var(--sp-md) var(--sp-xl) 0;
+}
+
+.tileGrid2x2 .tile::before {
+  content: '';
+  display: block;
+  width: 36ch;
+  max-width: 100%;
+  height: 1px;
+  background: var(--color-rule);
+  margin-bottom: var(--sp-lg);
+}
+
+.tileNumber {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-muted);
+}
+
+.tileTitle {
+  font-size: var(--text-xl);
+  font-weight: var(--font-medium);
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-snug);
+  color: var(--color-text);
+}
+
+.tileBody {
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  line-height: var(--lh-lg);
+  color: var(--color-muted);
+  max-width: 36ch;
+}
+
+/* ─────────────────────────────────────────────────────
+   Split layout — 50/50 prose + figure
+───────────────────────────────────────────────────── */
+.splitGrid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: var(--sp-section) var(--col-gap);
+  padding: var(--sp-section) var(--gutter);
+  align-items: center;
+}
+
+.splitText {
+  grid-column: 1 / 7;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-lg);
+}
+
+.splitText > p {
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  line-height: var(--lh-lg);
+  color: var(--color-text);
+}
+
+.splitFigure {
+  grid-column: 7 / 13;
+}
+
+.splitFigure :global(figure) {
+  margin: 0;
+}
+
+/* ─────────────────────────────────────────────────────
+   Figure wrappers — 12-col grid containers for figures
+   `fullBleedFigure` spans 1–13 (climactic moments)
+   `figureMedium`    spans 1–9   (left-anchored, ~2/3)
+───────────────────────────────────────────────────── */
+.fullBleedFigure,
+.figureMedium {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  column-gap: var(--col-gap);
+  padding: var(--sp-section) var(--gutter);
+}
+
+.fullBleedFigure :global(figure) {
+  grid-column: 1 / 13;
+  margin: 0;
+}
+
+.figureMedium :global(figure) {
+  grid-column: 1 / 10;
+  margin: 0;
+}
+
+/* ─────────────────────────────────────────────────────
+   Pull quote — full-width display moment
+───────────────────────────────────────────────────── */
+.pullQuote {
+  margin-top: var(--sp-large-section);
+  padding: var(--sp-large-section) var(--gutter) 0;
+  border-top: 1px solid var(--color-rule);
+}
+
+.pullQuote p {
+  grid-column: 1 / 13;
+  font-size: clamp(var(--text-3xl), 4.5vw, var(--text-5xl));
+  font-weight: var(--font-light);
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  color: var(--color-text);
+  max-width: 24ch;
+}
+
+/* ─────────────────────────────────────────────────────
+   Stat callout — keynote-style, full bleed
+───────────────────────────────────────────────────── */
+.statCallout {
+  border-top: 1px solid var(--color-rule);
+  padding: var(--sp-xl) 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-sm);
+  max-width: 440px;
+}
+
+.statValue {
+  font-size: var(--text-3xl);
+  font-weight: var(--font-medium);
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  color: var(--color-text);
+}
+
+.statLabel {
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  line-height: var(--lh-lg);
+  color: var(--color-text);
+}
+
+.statSource {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-muted);
+  text-transform: uppercase;
+  margin-top: var(--sp-xs);
+}
+
+/* ─────────────────────────────────────────────────────
+   Footer
+───────────────────────────────────────────────────── */
+.footer {
+  margin-top: var(--sp-large-section);
+  padding: var(--sp-section) var(--gutter) 0;
+  border-top: 1px solid var(--color-rule);
+}
+
+.ndaNote {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-muted);
+  font-style: italic;
+}
+
+/* ─────────────────────────────────────────────────────
+   Responsive
+───────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .hero {
+    min-height: 0;
+    padding: var(--sp-section) var(--gutter);
+  }
+  .heroGrid {
+    grid-template-rows: auto auto auto;
+    min-height: 0;
+  }
+  .heroBack,
+  .heroLockup,
+  .heroFigure {
+    grid-column: 1 / 13;
+  }
+  .heroBack    { grid-row: 1; }
+  .heroFigure  { grid-row: 2; aspect-ratio: 4/5; }
+  .heroLockup  { grid-row: 3; }
+  .label,
+  .sectionTitle {
+    grid-column: 1 / 13;
+    margin-bottom: var(--sp-xl);
+  }
+  .body,
+  .bodyTwoCol,
+  .quoteUnder,
+  .split2,
+  .subSectionLead,
+  .gridAside .label,
+  .gridAside .body,
+  .gridAside .figureCell,
+  .gridAside .quoteCell,
+  .gridThirds .sectionTitle,
+  .gridThirds .label,
+  .gridThirds .body,
+  .gridThirds .figureCell,
+  .gridFramework .sectionTitle,
+  .frameworkBody,
+  .fullVisual {
+    grid-column: 1 / 13;
+    grid-row: auto;
+  }
+  .bodyTwoCol,
+  .bodyColumns {
+    column-count: 1;
+  }
+  .statRow {
+    grid-template-columns: 1fr;
+    gap: var(--sp-xl);
+  }
+  .quoteUnder {
+    margin-top: var(--sp-xl);
+  }
+  .split2 {
+    grid-template-columns: 1fr;
+  }
+  .splitText,
+  .splitFigure {
+    grid-column: 1 / 13;
+  }
+  .tileGrid5 .tile,
+  .tileGrid3 .tile,
+  .tileGrid2x2 .tile {
+    grid-column: span 12 !important;
+    border-right: none !important;
+    border-bottom: 1px solid var(--color-rule) !important;
+    padding: var(--sp-xl) 0 !important;
+  }
+  .tileGrid5 .tile:last-child,
+  .tileGrid3 .tile:last-child,
+  .tileGrid2x2 .tile:last-child {
+    border-bottom: none !important;
+  }
+}

--- a/site/src/app/ux/work/instana-ai-strategy/page.tsx
+++ b/site/src/app/ux/work/instana-ai-strategy/page.tsx
@@ -1,0 +1,564 @@
+import type { Metadata } from 'next'
+import Figure from '@/components/ux/work/Figure'
+import styles from './page.module.css'
+
+export const metadata: Metadata = {
+  title: 'Instana AI Strategy — Andrew Whited',
+}
+
+export default function InstanaAIStrategyPage() {
+  return (
+    <main className={styles.page}>
+      {/* ───────────────────────────── HERO ───────────────────────────── */}
+      <section className={styles.hero}>
+        <div className={styles.heroGrid}>
+          <a href="/ux#work" className={styles.heroBack} aria-label="Back to work">←</a>
+          <div className={styles.heroLockup}>
+            <div className={styles.heroTitleGroup}>
+              <h1 className={styles.heroTitle}>
+                Instana<br />AI Strategy
+              </h1>
+              <p className={styles.heroSummary}>
+                A unifying interaction model for AI in observability — built before agentic patterns had a name.
+              </p>
+            </div>
+            <dl className={styles.heroMeta}>
+              <div className={styles.heroMetaItem}>
+                <dt>Client</dt>
+                <dd>IBM</dd>
+              </div>
+              <div className={styles.heroMetaItem}>
+                <dt>Role</dt>
+                <dd>Senior Design Lead</dd>
+              </div>
+              <div className={styles.heroMetaItem}>
+                <dt>Year</dt>
+                <dd>2023–2025</dd>
+              </div>
+            </dl>
+          </div>
+          <div className={styles.heroFigure}>
+            <Figure
+              kind="hero"
+              title="Hub-and-spoke interaction model"
+              width="full"
+              hideCaption
+              fill
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* ───────────────────────────── THESIS ───────────────────────────── */}
+      <section className={styles.section}>
+        <div className={styles.grid}>
+          <h2 className={styles.sectionTitle}>Thesis</h2>
+          <div className={styles.bodyTwoCol}>
+            <p>
+              At Instana, a new focus on AI was starting to surface across the product in disconnected
+              pockets: incident summarization in one squad, predictive alerting in another, chatbot research
+              in a third. The work was siloed and narrow in focus.
+            </p>
+            <p>
+              I saw the trajectory of the market, the AI direction coming out of IBM, and the Instana need
+              for a bigger strategy and a unifying interaction model. The framework I built defined which
+              AI capabilities the product should reach for and how they should connect, with a hub-and-spoke
+              interaction model at its center: the chatbot as hub, bidirectionally connected to the rest of
+              the product.
+            </p>
+            <p>
+              This was early. Agentic AI did not yet have a settled name in the industry, and the interaction
+              patterns had not yet crystallized into conventions.
+            </p>
+            <p>
+              I was already leading three concurrent design efforts at Instana. I started this initiative
+              as a fourth, pulled in collaborators across PM, engineering, and architecture, and shared the
+              framework as scaffolding for other teams exploring AI in their own corners. This set the stage
+              for the AI work that shows up in the product today.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ───────────────────────────── §1 THE SMALL ASK ───────────────────────────── */}
+      <section className={styles.section}>
+        <div className={`${styles.grid} ${styles.gridThirds}`}>
+          <h2 className={styles.sectionTitle}>The small ask</h2>
+          <div className={styles.body}>
+            <p>
+              The assignment that landed on one of my teams was small. Design a Generate-Summary button on
+              the incident page. The user clicks, the system writes a paragraph of natural language describing
+              what was wrong with the incident, the user moves on. The capability already existed in the
+              product in a guardrailed form, surfaced through a single button on a single page. My job was
+              to make it more useful.
+            </p>
+            <p>
+              The brief made sense. Incidents in the product are dense by design: grouped alerts, root-cause
+              analysis, related events, automation policies, ongoing collaboration notes. Reading one quickly
+              is hard. A summary button is a reasonable response to that, and shipping it as a self-contained,
+              guardrailed feature was a reasonable way to handle a still-uncertain technology.
+            </p>
+            <p>On its own, it would have shipped fine.</p>
+          </div>
+          <div className={styles.figureCell}>
+            <Figure
+              kind="screenshot"
+              title="The existing Generate-Summary button"
+              caption="Notes and Activity panel on an incident page, with the “Preview” tag visible."
+              width="full"
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* ───────────────────────────── §2 THE REALIZATION ───────────────────────────── */}
+      <section className={styles.section}>
+        <div className={styles.grid}>
+          <h2 className={styles.sectionTitle}>The realization</h2>
+          <div className={styles.bodyTwoCol}>
+            <p>
+              Once I started looking past the button, the picture across the product was harder to ignore.
+            </p>
+            <p>
+              Smart alerts had been doing pattern detection for years without ever being framed as AI.
+              Predictive alerting was being sketched out on another team. Chatbot research was running on
+              my own team alongside the summary button. Other AI possibilities were being explored elsewhere
+              in the product. Each effort was reasonable in isolation, but there was no one whose job it was
+              to see how the pieces fit together.
+            </p>
+            <p>
+              The questions that needed asking were obvious once you stepped back. How do all these
+              capabilities relate to each other? What is the user&rsquo;s mental model of AI in the product?
+              Where does AI live, and where does it not? Without answers, the product was going to ship a
+              half-dozen disconnected AI features, each making its own assumptions about how the user should
+              encounter them.
+            </p>
+          </div>
+          <blockquote className={styles.quoteUnder}>
+            <p>It wasn&rsquo;t anyone&rsquo;s job, so I made it mine.</p>
+          </blockquote>
+        </div>
+      </section>
+
+      {/* ───────────────────────────── §3 THE FRAMEWORK ───────────────────────────── */}
+      <section className={styles.section}>
+        <div className={styles.gridFramework}>
+          <h2 className={styles.sectionTitle}>The framework</h2>
+          <div className={styles.frameworkBody}>
+
+            {/* Section intro */}
+            <div className={styles.frameworkIntro}>
+              <p>
+                My response was a framework. A top-down articulation of what AI in the product should be,
+                how its pieces should connect, and how users should encounter it.
+              </p>
+              <p>
+                The framework had four parts that fit together: a capabilities taxonomy, an interaction model,
+                a set of UI integration patterns, and a technical architecture beneath them. Each part answered
+                a question that was not being asked anywhere else in the product.
+              </p>
+            </div>
+
+            {/* Subsection: Capabilities taxonomy */}
+            <div className={styles.subSection}>
+              <header>
+                <div className={styles.label}>Capabilities taxonomy</div>
+              </header>
+              <div className={styles.body}>
+                <p>
+                  The starting move was naming what AI actually was inside the product. Five capability
+                  types, each playing a different role.
+                </p>
+                <p>
+                  Naming the types gave every team a vocabulary to locate their work in. The summary button
+                  sat in Generative. Smart alerts sat in Predictive. Both were AI in a meaningful sense, and
+                  both belonged in the same picture.
+                </p>
+              </div>
+              <div className={styles.tileGrid5}>
+                <div className={styles.tile}>
+                  <div className={styles.tileNumber}>01</div>
+                  <div className={styles.tileTitle}>Generative</div>
+                  <div className={styles.tileBody}>Interprets, summarizes, suggests. The chatbot lives here.</div>
+                </div>
+                <div className={styles.tile}>
+                  <div className={styles.tileNumber}>02</div>
+                  <div className={styles.tileTitle}>Predictive</div>
+                  <div className={styles.tileBody}>Detects anomalies, surfaces what&rsquo;s coming. Smart alerts and predictive alerting.</div>
+                </div>
+                <div className={styles.tile}>
+                  <div className={styles.tileNumber}>03</div>
+                  <div className={styles.tileTitle}>RAG</div>
+                  <div className={styles.tileBody}>Pulls in documentation, runbooks, and historical context to ground responses in source material.</div>
+                </div>
+                <div className={styles.tile}>
+                  <div className={styles.tileNumber}>04</div>
+                  <div className={styles.tileTitle}>Agentic</div>
+                  <div className={styles.tileBody}>Performs actions and remediations on the user&rsquo;s behalf.</div>
+                </div>
+                <div className={styles.tile}>
+                  <div className={styles.tileNumber}>05</div>
+                  <div className={styles.tileTitle}>Assistive</div>
+                  <div className={styles.tileBody}>Sharpens search, recommendations, and small enhancements throughout the product.</div>
+                </div>
+              </div>
+            </div>
+
+            {/* Subsection: Interaction model — hub-and-spoke */}
+            <div className={styles.subSection}>
+              <header>
+                <div className={styles.label}>Interaction model — the chatbot as hub</div>
+              </header>
+              <div className={styles.body}>
+                <p>
+                  The capabilities had to connect, not just coexist. I put the chatbot at the center of the
+                  interaction model and made the rest of the product the spokes around it.
+                </p>
+                <p>
+                  The chatbot pointed outward to do work in the product. It navigated the user to relevant
+                  views. It built things (dashboards, runbooks, summaries) on demand. It served as the entry
+                  point for AI features embedded elsewhere in the UI.
+                </p>
+                <p>
+                  The product pointed back to do work in the chatbot. A probable root cause analysis or an
+                  insight on a page could launch a chat thread for deeper investigation. AI outputs landed in
+                  the chat panel for follow-up.
+                </p>
+                <p>The chatbot acted as connective tissue between AI capabilities and the rest of the product.</p>
+              </div>
+              <div className={styles.fullBleedFigure}>
+                <Figure
+                  kind="hero"
+                  title="Hub-and-spoke interaction model"
+                  caption="Chatbot at center; bidirectional spokes — outward to navigate, build, and trigger embedded AI; inward from page elements that launch chat threads."
+                  width="full"
+                />
+              </div>
+            </div>
+
+            {/* Subsection: UI integration models — 2x2 tile grid */}
+            <div className={styles.subSection}>
+              <header>
+                <div className={styles.label}>UI integration models</div>
+              </header>
+              <div className={styles.body}>
+                <p>
+                  Knowing what AI is and how it connects was not enough. The framework also had to specify
+                  where AI shows up in the interface and what kind of behavior lives at each surface. Four
+                  patterns covered the territory.
+                </p>
+                <p>
+                  Each pattern had a different design challenge. Knowing the framework allowed new features
+                  to be built systematically and efficiently within it.
+                </p>
+              </div>
+              <div className={styles.tileGrid2x2}>
+                <div className={styles.tile}>
+                  <div className={styles.tileNumber}>01</div>
+                  <div className={styles.tileTitle}>Self-Contained Chat</div>
+                  <div className={styles.tileBody}>The dedicated chat interface, available across the product. Open-ended Q&amp;A, debugging, and the bidirectional interactions all happen here.</div>
+                </div>
+                <div className={styles.tile}>
+                  <div className={styles.tileNumber}>02</div>
+                  <div className={styles.tileTitle}>Chat-Driven Navigation</div>
+                  <div className={styles.tileBody}>AI woven into how the user moves through the product. The chat surfaces the relevant page; search gets generative reformulation; the product becomes navigable in plain language.</div>
+                </div>
+                <div className={styles.tile}>
+                  <div className={styles.tileNumber}>03</div>
+                  <div className={styles.tileTitle}>Artifact Creation</div>
+                  <div className={styles.tileBody}>Generative AI embedded in authoring surfaces. Build a dashboard, draft a query, scaffold a runbook inside the tools the user is already working in.</div>
+                </div>
+                <div className={styles.tile}>
+                  <div className={styles.tileNumber}>04</div>
+                  <div className={styles.tileTitle}>Contextual Launch</div>
+                  <div className={styles.tileBody}>AI features attached to specific objects in the product. The Summarize button on an incident; the same pattern on a Suggest button for a query, an Explain button for a metric.</div>
+                </div>
+              </div>
+            </div>
+
+            {/* Subsection: Technical architecture */}
+            <div className={styles.subSection}>
+              <header>
+                <div className={styles.label}>Technical architecture</div>
+              </header>
+              <div className={styles.body}>
+                <p>
+                  I worked through the technical layer too. The framework had to be buildable, and that meant
+                  understanding what the systems could actually do at the engineering level.
+                </p>
+                <p>
+                  A user input goes to the LLM, which branches into either natural-language-to-API calls
+                  (REST, GraphQL) for querying Instana data or natural-language-to-widget for generating UI
+                  artifacts, then returns a response back through the chat. GraphQL handled unified queries.
+                  REST handled specific endpoints. The LLM acted as orchestrator over both.
+                </p>
+                <p>
+                  Understanding this gave me the language to translate technical possibilities up to product
+                  leadership and design constraints down to engineers. The framework had to be buildable, not
+                  aspirational.
+                </p>
+                <p>
+                  Together, the four parts gave the product a system to build into. The summary button on the
+                  incident page was one instance of one pattern (Contextual Launch) within one capability
+                  (Generative). Once the system was named, every other AI feature in the product had a place
+                  to land and a way to connect.
+                </p>
+              </div>
+              <div className={styles.fullBleedFigure}>
+                <Figure
+                  kind="flow"
+                  title="Technical flow"
+                  caption="Input → LLM → branch (NL→API for REST/GraphQL · NL→Widget for UI artifacts) → Response."
+                  width="full"
+                />
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </section>
+
+      {/* ───────────────────────────── §4 THE CONCEPTS ───────────────────────────── */}
+      <section className={styles.section}>
+        <div className={styles.gridFramework}>
+          <h2 className={styles.sectionTitle}>The concepts</h2>
+
+          {/* Section intro */}
+          <div className={styles.frameworkBody}>
+            <div className={styles.frameworkIntro}>
+              <p>
+                I designed use cases to test the framework and to evangelize it. Each one exercised a
+                different part of the system, often more than one at a time.
+              </p>
+            </div>
+          </div>
+
+          {/* Subsection: Incident summarization */}
+          <div className={styles.frameworkBody}>
+            <div className={styles.subSection}>
+              <header>
+                <div className={styles.label}>Incident summarization — shipped Q1 2025</div>
+              </header>
+              <div className={styles.body}>
+                <p>
+                  The Summarize button itself shipped in Q1 2025. This was the original feature behind the
+                  strategy, and it landed in the framework as a Contextual Launch: AI attached to a specific
+                  object in the product, surfaced at the moment of need, generating output that lives in
+                  context.
+                </p>
+                <p>
+                  Treating the button as one instance of a pattern, instead of a one-off feature, meant
+                  designing it to coexist gracefully with everything else AI was going to do across the
+                  product.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div className={styles.fullVisual}>
+            <Figure
+              kind="screenshot"
+              title="Shipped Summarize feature in context"
+              caption="Notes &amp; Activity panel with surrounding incident data and the AI summary output once invoked."
+              width="full"
+            />
+          </div>
+
+          {/* Subsection: Audience-aware sharing */}
+          <div className={styles.frameworkBody}>
+            <div className={styles.subSection}>
+              <header>
+                <div className={styles.label}>Audience-aware sharing</div>
+              </header>
+              <div className={styles.body}>
+                <p>
+                  When something breaks in production, an incident gets shared many times to many different
+                  people. Executives need to know impact and duration. On-call SREs need probable cause and
+                  potential fixes. Downstream engineers need the full technical picture.
+                </p>
+                <p>
+                  I designed a sharing flow where the user picks who the share is for, and the AI generates
+                  a summary tailored to that audience:
+                </p>
+                <ul className={styles.list}>
+                  <li><em>Executive overview.</em> Top-line impact: who&rsquo;s affected, how long, severity.</li>
+                  <li><em>Triage report.</em> Probable cause and possible solutions for whoever&rsquo;s getting paged.</li>
+                  <li><em>Detailed share.</em> Full technical detail for the engineer who will do the work.</li>
+                </ul>
+                <p>
+                  The flow sat inside the existing share modal — a third option alongside invite a
+                  collaborator and share a link, with the audience picker driving the template. This is
+                  Artifact Creation, not a chat conversation. The user clicks share, picks the audience
+                  type, and the system generates a bespoke summary on demand.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div className={styles.fullVisual}>
+            <Figure
+              kind="multi"
+              frames={3}
+              title="Audience-aware share — three-screen concept flow"
+              caption="Incident page with Share affordance · sharing modal with three audience options · generated tailored summary view."
+              width="full"
+            />
+          </div>
+
+          {/* Subsection: Chat-to-dashboard */}
+          <div className={styles.frameworkBody}>
+            <div className={styles.subSection}>
+              <header>
+                <div className={styles.label}>Generating a dashboard from chat</div>
+              </header>
+              <div className={styles.body}>
+                <p>
+                  A user asks the chatbot something specific: &ldquo;Show me latency for our checkout service
+                  over the last week.&rdquo; The chatbot&rsquo;s answer is the dashboard itself. It builds it
+                  on the fly, then navigates the user to it. The user lands on a new persistent dashboard
+                  view, ready to be saved, shared, or extended.
+                </p>
+                <p>
+                  This single flow exercises three patterns at once. It starts in Self-Contained Chat (the
+                  user asks). It produces an Artifact (the dashboard). It ends in Chat-Driven Navigation
+                  (the user lands on the new view). The chatbot moves from answerer to builder to guide in
+                  one user action.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div className={styles.fullVisual}>
+            <Figure
+              kind="multi"
+              frames={3}
+              status="tbd"
+              title="Chat-to-dashboard concept flow"
+              caption="Chat input · chatbot generating a dashboard inline · user landed on the new persistent dashboard view."
+              width="full"
+            />
+          </div>
+
+          {/* Subsection: Runbooks */}
+          <div className={styles.frameworkBody}>
+            <div className={styles.subSection}>
+              <header>
+                <div className={styles.label}>Runbooks with a chat refinement loop</div>
+              </header>
+              <div className={styles.body}>
+                <p>
+                  When an incident hits, the response often involves running remediation steps that may or
+                  may not have been documented before. I designed a flow where the chatbot, anchored to the
+                  incident at hand, generates a candidate runbook, pulling from documentation, prior incident
+                  histories, and the engineer&rsquo;s intent in the moment.
+                </p>
+                <p>
+                  The runbook lands in the product as an artifact. The user can run it as-is, or click into
+                  it to open a chat thread for refinement: &ldquo;Make this safer,&rdquo; &ldquo;Skip step
+                  three,&rdquo; &ldquo;Add a rollback at the end.&rdquo; The chat takes the artifact,
+                  modifies it, and returns it to the product.
+                </p>
+                <p>
+                  This is Artifact Creation feeding into the bidirectional product-to-chat loop from the
+                  interaction model, and pointing toward Agentic AI, where the next step is the chatbot
+                  offering to execute the runbook itself.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div className={styles.fullVisual}>
+            <Figure
+              kind="multi"
+              frames={3}
+              status="tbd"
+              title="AI-generated runbook with chat-refinement flow"
+              caption="Chatbot generating a candidate runbook · runbook in the product with a “Refine in chat” affordance · chat thread refining the runbook."
+              width="full"
+            />
+          </div>
+
+          {/* Closing wrap-up */}
+          <div className={styles.frameworkBody}>
+            <div className={styles.body}>
+              <p>
+                Each use case touched a different part of the framework. The Summarize button proved
+                Contextual Launch could ship. Audience-aware sharing was Artifact Creation, tuned to the
+                recipient. The dashboard flow chained three patterns into one user action. The runbook
+                loop pointed at the Agentic edge. The framework was producing things that fit together
+                as a system.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ───────────────────────────── §5 THE PITCH ───────────────────────────── */}
+      <section className={styles.section}>
+        <div className={styles.gridFramework}>
+          <h2 className={styles.sectionTitle}>The pitch &amp; where it went</h2>
+
+          {/* All synthesis + post-departure prose — 2-col flow */}
+          <div className={styles.frameworkBody}>
+            <div className={styles.bodyColumns}>
+              <p>
+                I took the use cases and paired them with the system&rsquo;s IA and taxonomy. The synthesis
+                ran end-to-end: vision, capabilities taxonomy, four UI integration models, hub-and-spoke
+                interaction model, technical flow, phased roadmap, risks and ethics. The roadmap itself
+                moved through four phases (foundations, expanded AI features, automated actions, adaptive
+                AI), the last two of which are the territory the industry now calls agentic.
+              </p>
+              <p>
+                I captured the synthesis in a Mural and built pitch decks, flows, and other artifacts from
+                it for different audiences. I started sharing the work out, working with the PMs and
+                architects I had sold on the vision. The aim was to turn the synthesis into a funded work
+                stream with portfolio-level sponsorship behind it.
+              </p>
+              <p>
+                After presenting and documenting the work, I separated from the company. The framework
+                didn&rsquo;t ship under my name, but the direction it was pointing in continued to shape
+                the product.
+              </p>
+              <p>
+                Since I left, Instana has shipped Intelligent Incident Investigation (preview), using
+                agentic AI for faster root cause identification — in the same chatbot-as-investigation-tool
+                direction the framework was pushing toward. They also released GenAI Observability for
+                monitoring AI applications running on the platform.
+              </p>
+              <p>
+                The strategic direction the framework was articulating is where the product went.
+              </p>
+            </div>
+          </div>
+
+          {/* Stat callout — Gartner Leader, compact block */}
+          <div className={styles.frameworkBody}>
+            <div className={styles.statCallout}>
+              <div className={styles.statValue}>Leader</div>
+              <div className={styles.statLabel}>
+                Gartner Magic Quadrant for Observability Platforms — July 2025
+              </div>
+              <div className={styles.statSource}>IBM Instana Observability</div>
+            </div>
+          </div>
+
+          {/* Reflection — single column at the bottom */}
+          <div className={styles.frameworkBody}>
+            <div className={styles.body}>
+              <p>
+                The work was rewarding for what it required: looking past the assignment in front of me to
+                the system underneath, designing for a technology before its conventions had settled, and
+                trying to bring others along to a vision that hadn&rsquo;t yet been blessed from above.
+                That kind of work doesn&rsquo;t always fit within your tenure. Products at this scale are
+                built through a ton of collaboration, and it&rsquo;s fun getting to shape the path of
+                something that continues to live on.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <footer className={styles.footer}>
+        <p className={styles.ndaNote}>
+          Note: Due to NDAs, some assets have been redrawn or generalized.
+        </p>
+      </footer>
+    </main>
+  )
+}

--- a/site/src/components/ux/work/Figure.module.css
+++ b/site/src/components/ux/work/Figure.module.css
@@ -1,0 +1,127 @@
+.figure {
+  margin: var(--sp-section) 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-lg);
+}
+
+.fill {
+  margin: 0;
+  height: 100%;
+}
+
+.fill .placeholder,
+.fill .multi {
+  height: 100%;
+  flex: 1;
+}
+
+.column {
+  /* Sits within prose column; no extra width */
+}
+
+.wide {
+  /* Breaks out of prose column to a wider band */
+  width: calc(100% + 240px);
+  margin-left: -120px;
+}
+
+.full {
+  /* Full content max-width */
+  width: 100%;
+}
+
+.placeholder {
+  width: 100%;
+  border: 1px solid var(--color-rule);
+  background:
+    repeating-linear-gradient(
+      135deg,
+      transparent 0,
+      transparent 11px,
+      rgba(255, 255, 255, 0.025) 11px,
+      rgba(255, 255, 255, 0.025) 12px
+    );
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.placeholderInner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--sp-xs);
+}
+
+.kind {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  letter-spacing: var(--tracking-wider);
+  color: var(--color-muted);
+  text-transform: uppercase;
+}
+
+.multi {
+  display: grid;
+  gap: var(--sp-lg);
+}
+
+.frame {
+  border: 1px solid var(--color-rule);
+  background:
+    repeating-linear-gradient(
+      135deg,
+      transparent 0,
+      transparent 11px,
+      rgba(255, 255, 255, 0.025) 11px,
+      rgba(255, 255, 255, 0.025) 12px
+    );
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.frameLabel {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-muted);
+}
+
+.caption {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-xs);
+  font-size: var(--text-sm);
+}
+
+.captionTitle {
+  font-weight: var(--font-medium);
+  color: var(--color-text);
+  line-height: var(--lh-sm);
+}
+
+.tbd {
+  font-weight: var(--font-medium);
+  letter-spacing: var(--tracking-wide);
+  color: var(--color-muted);
+  text-transform: uppercase;
+  font-size: var(--text-sm);
+}
+
+.captionBody {
+  color: var(--color-muted);
+  line-height: var(--lh-sm);
+}
+
+@media (max-width: 900px) {
+  .wide {
+    width: 100%;
+    margin-left: 0;
+  }
+  .multi {
+    grid-template-columns: 1fr !important;
+  }
+}

--- a/site/src/components/ux/work/Figure.tsx
+++ b/site/src/components/ux/work/Figure.tsx
@@ -1,0 +1,73 @@
+import styles from './Figure.module.css'
+
+type FigureKind = 'screenshot' | 'diagram' | 'matrix' | 'flow' | 'hero' | 'multi'
+
+type Props = {
+  kind: FigureKind
+  title: string
+  caption?: string
+  status?: 'tbd'
+  frames?: number
+  width?: 'column' | 'wide' | 'full'
+  hideCaption?: boolean
+  fill?: boolean
+}
+
+const aspectByKind: Record<FigureKind, string> = {
+  screenshot: '16 / 10',
+  diagram: '4 / 3',
+  matrix: '4 / 3',
+  flow: '5 / 2',
+  hero: '4 / 5',
+  multi: '5 / 2',
+}
+
+export default function Figure({
+  kind,
+  title,
+  caption,
+  status,
+  frames,
+  width = 'column',
+  hideCaption,
+  fill,
+}: Props) {
+  const widthClass =
+    width === 'wide' ? styles.wide : width === 'full' ? styles.full : styles.column
+
+  return (
+    <figure className={`${styles.figure} ${widthClass} ${fill ? styles.fill : ''}`}>
+      {kind === 'multi' && frames ? (
+        <div className={styles.multi} style={{ gridTemplateColumns: `repeat(${frames}, 1fr)` }}>
+          {Array.from({ length: frames }).map((_, i) => (
+            <div
+              key={i}
+              className={styles.frame}
+              style={fill ? undefined : { aspectRatio: '3 / 4' }}
+            >
+              <span className={styles.frameLabel}>Frame {i + 1}</span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div
+          className={styles.placeholder}
+          style={fill ? undefined : { aspectRatio: aspectByKind[kind] }}
+        >
+          <div className={styles.placeholderInner}>
+            <span className={styles.kind}>{kind}</span>
+          </div>
+        </div>
+      )}
+      {!hideCaption && (
+        <figcaption className={styles.caption}>
+          <span className={styles.captionTitle}>
+            {title}
+            {status === 'tbd' && <span className={styles.tbd}> · TBD</span>}
+          </span>
+          {caption && <span className={styles.captionBody}>{caption}</span>}
+        </figcaption>
+      )}
+    </figure>
+  )
+}


### PR DESCRIPTION
Hardcoded prototype at /ux/work/instana-ai-strategy to settle the design language for UX work pages before porting to Sanity. CS2 writeup used as example content; placeholder Figure component for not-yet-created assets.

- Hero: title/tagline/meta stacked left, image right, vertical drama via space-between
- Section variants: bodyTwoCol (thesis-style 2-col flow), gridAside (text + side aside), gridThirds (title|text|image), gridFramework (sticky-left title, frameworkBody right band, fullVisual breakouts for flow climaxes)
- Tile grids: 5-tile vertical rules; 2x2 short HRs above each tile matched to body text width; 3-tile demoted to em-dash bullet list
- Stat callout: compact card at text-3xl, max-width 440px, single top rule
- Layout drops max-width wrapper constraint to match rest of site
- Backfills session notes for prior perf-audit work and adds .claude/ to gitignore