### PR TITLE
Phase 1 launch: redirect apex to ux subdomain

### DIFF
--- a/site/src/app/(main)/layout.tsx
+++ b/site/src/app/(main)/layout.tsx
@@ -5,8 +5,6 @@ import CartButton from '@/components/CartButton'
 
 const CartDrawer = dynamic(() => import('@/components/CartDrawer'))
 
-const comingSoon = process.env.COMING_SOON === 'true'
-
 export default function MainLayout({
   children,
 }: {
@@ -14,13 +12,9 @@ export default function MainLayout({
 }) {
   return (
     <CartProvider>
-      {!comingSoon && (
-        <>
-          <Nav />
-          <CartButton />
-          <CartDrawer />
-        </>
-      )}
+      <Nav />
+      <CartButton />
+      <CartDrawer />
       {children}
     </CartProvider>
   )

--- a/site/src/app/(main)/page.tsx
+++ b/site/src/app/(main)/page.tsx
@@ -1,16 +1,6 @@
-import { getHomePage, getUxPage } from '@/lib/sanity-queries'
+import { getHomePage } from '@/lib/sanity-queries'
 import { urlFor } from '@/lib/sanity'
 import styles from './home.module.css'
-
-import Hero from '@/components/ux/sections/Hero'
-import About from '@/components/ux/sections/About'
-import Credentials from '@/components/ux/sections/Credentials'
-import Links from '@/components/ux/sections/Links'
-import LogoOutlineStroke from '@/components/icons/LogoOutlineStroke'
-import LogoSolid from '@/components/icons/LogoSolid'
-import GridOverlay from '@/components/GridOverlay'
-
-const comingSoon = process.env.COMING_SOON === 'true'
 
 function heroImageStyles(image: any) {
   if (!image) return undefined
@@ -28,52 +18,7 @@ function heroImageStyles(image: any) {
   return style
 }
 
-async function ComingSoonHome() {
-  const page = await getUxPage()
-
-  const resumeUrl = page?.resumeFile?.asset
-    ? `https://cdn.sanity.io/files/uwr1du4g/production/${page.resumeFile.asset._ref.replace('file-', '').replace('-pdf', '.pdf')}`
-    : '/resume.pdf'
-
-  return (
-    <div data-theme="ux" className="ux-root" style={{ minHeight: '100svh', backgroundColor: 'var(--color-bg)', position: 'relative', overflow: 'hidden' }}>
-      <LogoOutlineStroke className="ux-bg-logo" />
-      <div style={{ position: 'relative', zIndex: 1 }}>
-        <header style={{ padding: 'var(--spacing-m) var(--grid-margin)' }}>
-          <div style={{ height: '20px', width: 'fit-content' }}>
-            <LogoSolid />
-          </div>
-        </header>
-        <main className="ux-home">
-          <Hero text={page?.heroText} />
-          <About
-            heading={page?.aboutHeading}
-            themes={page?.aboutThemes}
-          />
-          <Credentials
-            image={page?.image ? urlFor(page.image).width(800).quality(80).auto('format').url() : undefined}
-            imageHotspot={page?.image?.hotspot}
-            publications={page?.publications}
-            talks={page?.talks}
-          />
-          <Links
-            footerCopy={page?.footerCopy}
-            linkedinUrl={page?.linkedinUrl}
-            resumeUrl={resumeUrl}
-            studioUrl={page?.studioUrl}
-          />
-        </main>
-        <GridOverlay />
-      </div>
-    </div>
-  )
-}
-
 export default async function Home() {
-  if (comingSoon) {
-    return <ComingSoonHome />
-  }
-
   const page = await getHomePage()
 
   return (

--- a/site/src/middleware.ts
+++ b/site/src/middleware.ts
@@ -2,16 +2,16 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 /*
-  Subdomain routing + coming-soon mode.
+  Subdomain routing.
 
   Production:
-    andrewwhited.com      → serves (main) routes (/, /studio, /objects, …)
+    andrewwhited.com      → 301 redirect to ux.andrewwhited.com (same path)
+    www.andrewwhited.com  → 301 redirect to ux.andrewwhited.com (same path)
     ux.andrewwhited.com   → internally rewrites to /ux/* paths
 
-  Coming-soon mode (COMING_SOON=true env var):
-    All routes except / and /sanity redirect to /.
-    The home page renders a UX-lite landing page.
-    Remove the env var to go live with the full site.
+  Phase 1 posture: the apex redirect trains people toward the canonical
+  ux.andrewwhited.com URL. To start serving the studio (main) site from
+  the apex (Phase 2), remove the apex redirect block below.
 
   Local development options:
     Option A (recommended): Add to /etc/hosts:
@@ -25,25 +25,19 @@ import type { NextRequest } from 'next/server'
     full local fidelity.
 */
 
-const comingSoon = process.env.COMING_SOON === 'true'
-
 export function middleware(request: NextRequest) {
   const hostname = request.headers.get('host') || ''
-  const { pathname } = request.nextUrl
+  const { pathname, search } = request.nextUrl
 
-  // Coming-soon mode: only allow / and /sanity, redirect everything else
-  if (comingSoon) {
-    const isAllowed =
-      pathname === '/' ||
-      pathname.startsWith('/sanity')
+  const isApex =
+    hostname === 'andrewwhited.com' ||
+    hostname === 'www.andrewwhited.com'
 
-    if (!isAllowed) {
-      const url = request.nextUrl.clone()
-      url.pathname = '/'
-      return NextResponse.redirect(url)
-    }
-
-    return NextResponse.next()
+  if (isApex) {
+    return NextResponse.redirect(
+      `https://ux.andrewwhited.com${pathname}${search}`,
+      301,
+    )
   }
 
   const isUxSubdomain =


### PR DESCRIPTION
Removes COMING_SOON gating. Apex (andrewwhited.com, www.) now 301-redirects to ux.andrewwhited.com preserving path, so the UX subdomain becomes the canonical URL while the studio (main) site stays parked for Phase 2.