### PR TITLE
Fix subdomain routing: clean URLs + static asset bypass

### DIFF
--- a/site/src/app/ux/work/instana-ai-strategy-test/page.tsx
+++ b/site/src/app/ux/work/instana-ai-strategy-test/page.tsx
@@ -12,7 +12,7 @@ export default function InstanaAIStrategyPage() {
       {/* ───────────────────────────── HERO ───────────────────────────── */}
       <section className={styles.hero}>
         <div className={styles.heroGrid}>
-          <a href="/ux#work" className={styles.heroBack} aria-label="Back to work">←</a>
+          <a href="/#work" className={styles.heroBack} aria-label="Back to work">←</a>
           <div className={styles.heroLockup}>
             <div className={styles.heroTitleGroup}>
               <h1 className={styles.heroTitle}>

--- a/site/src/components/UxNav.tsx
+++ b/site/src/components/UxNav.tsx
@@ -5,12 +5,12 @@ export default function UxNav() {
   return (
     <header className={styles.nav}>
       <div className={styles.inner}>
-        <a href="/ux#hero" className={styles.name} aria-label="Andrew Whited">
+        <a href="/#hero" className={styles.name} aria-label="Andrew Whited">
           <LogoSolid className={styles.navLogo} />
         </a>
         <nav className={styles.links} aria-label="Site navigation">
-          <a href="/ux#work">Work</a>
-          <a href="/ux#thoughts">Thoughts</a>
+          <a href="/#work">Work</a>
+          <a href="/#thoughts">Thoughts</a>
         </nav>
       </div>
     </header>

--- a/site/src/components/ux/sections/Thoughts.tsx
+++ b/site/src/components/ux/sections/Thoughts.tsx
@@ -19,7 +19,7 @@ export default function Thoughts({ items }: { items?: ThoughtItem[] }) {
         <ul className={`${styles.content} ${styles.thoughtList}`}>
           {(items ?? []).map((piece) => (
             <li key={piece._id}>
-              <Link href={`/ux/thoughts/${piece.slug?.current}`} className={styles.thought}>
+              <Link href={`/thoughts/${piece.slug?.current}`} className={styles.thought}>
                 <div className={styles.thoughtTitle}>{piece.title}</div>
                 <p className={`${styles.secondary} ${styles.thoughtSummary}`}>{piece.summary}</p>
                 <div className={styles.thoughtMeta}>

--- a/site/src/components/ux/sections/Work.tsx
+++ b/site/src/components/ux/sections/Work.tsx
@@ -20,7 +20,7 @@ export default function Work({ items }: { items?: WorkItem[] }) {
         <ul className={`${styles.content} ${styles.projectList}`}>
           {(items ?? []).map((project) => (
             <li key={project._id}>
-              <Link href={`/ux/work/${project.slug?.current}`} className={styles.project}>
+              <Link href={`/work/${project.slug?.current}`} className={styles.project}>
                 <div className={styles.projectTitle}>{project.title}</div>
                 <p className={`${styles.secondary} ${styles.projectSummary}`}>{project.summary}</p>
                 <div className={styles.projectMeta}>

--- a/site/src/components/ux/work/case-study-blocks.tsx
+++ b/site/src/components/ux/work/case-study-blocks.tsx
@@ -135,7 +135,7 @@ export function CaseStudyHero({ work }: { work: WorkData }) {
   return (
     <section className={styles.hero}>
       <div className={styles.heroGrid}>
-        <a href="/ux#work" className={styles.heroBack} aria-label="Back to work">
+        <a href="/#work" className={styles.heroBack} aria-label="Back to work">
           ←
         </a>
         <div className={styles.heroLockup}>

--- a/site/src/middleware.ts
+++ b/site/src/middleware.ts
@@ -29,6 +29,13 @@ export function middleware(request: NextRequest) {
   const hostname = request.headers.get('host') || ''
   const { pathname, search } = request.nextUrl
 
+  // Static assets in /public — pass through, never rewrite the path.
+  // Without this, an image at /thoughts/foo/1.svg requested from the
+  // ux. subdomain would be rewritten to /ux/thoughts/foo/1.svg and 404.
+  if (/\.[a-zA-Z0-9]+$/.test(pathname)) {
+    return NextResponse.next()
+  }
+
   const isApex =
     hostname === 'andrewwhited.com' ||
     hostname === 'www.andrewwhited.com'


### PR DESCRIPTION
## Summary
- Middleware bails out for static asset requests (file-extension paths) so images in /public load correctly on the ux. subdomain
- Internal links drop the /ux prefix so URLs on ux.andrewwhited.com stay clean

## Test plan
- [ ] Visit ux.andrewwhited.com/thoughts/user-testing-vs-user-teaching — images render
- [ ] Click into a work case study from the home page — URL is /work/<slug> not /ux/work/<slug>
- [ ] Nav links (Work, Thoughts, logo) jump to home anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)