### PR TITLE
Set dark theme-color on UX subdomain

### DIFF
--- a/site/src/app/ux/layout.tsx
+++ b/site/src/app/ux/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import UxNav from '@/components/UxNav'
 import GridOverlay from '@/components/GridOverlay'
 import ScrollFadeLogo from '@/components/ScrollFadeLogo'
@@ -7,6 +7,10 @@ export const metadata: Metadata = {
   title: 'Andrew Whited — Product Designer',
   description:
     'Senior product designer focused on complex systems, AI, and enterprise software.',
+}
+
+export const viewport: Viewport = {
+  themeColor: '#111110',
 }
 
 export default function UxLayout({


### PR DESCRIPTION
## Summary
- Adds viewport.themeColor = #111110 to the UX layout so iOS Safari's status bar and URL bar match the dark background

## Test plan
- [ ] On mobile Safari, ux.andrewwhited.com — status bar at top + URL bar at bottom render dark, no cream bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)