### PR TITLE
SEO polish: Article schema, 2x OG image, brighter watermark

### DIFF
--- a/site/src/app/ux/[slug]/article-schema.ts
+++ b/site/src/app/ux/[slug]/article-schema.ts
@@ -1,38 +1,70 @@
 // JSON-LD Article schema for individual case study + thought pages.
-// Keeps schema.org structure separate from page rendering.
+// Article is a Google rich-result type; CreativeWork is not. Always emit
+// Article (regardless of case-study vs essay) so the page is eligible for
+// the Article rich snippet treatment.
 
 const SITE_URL = 'https://ux.andrewwhited.com'
+const STUDIO_URL = 'https://andrewwhited.com'
 
 type ArticleInput = {
   slug: string
   title: string
   description?: string
   imageUrl?: string
-  datePublished?: string
+  /** Free-form year string from CMS: "2024", "2023–2025", etc. */
+  year?: string
   type: 'CaseStudy' | 'Essay'
 }
 
+// Convert a year string like "2024" or "2023–2025" to an ISO date.
+// Picks the end year if a range; falls back to undefined if unparseable.
+function yearToIsoDate(year?: string): string | undefined {
+  if (!year) return undefined
+  // Match any 4-digit years; if multiple, take the last (end of range).
+  const matches = year.match(/\d{4}/g)
+  if (!matches || matches.length === 0) return undefined
+  const endYear = matches[matches.length - 1]
+  return `${endYear}-01-01`
+}
+
 export function buildArticleSchema(input: ArticleInput) {
-  const articleType = input.type === 'CaseStudy' ? 'CreativeWork' : 'Article'
+  const datePublished = yearToIsoDate(input.year)
+  const dateModified = new Date().toISOString().slice(0, 10)
+
+  const image = input.imageUrl
+    ? {
+        '@type': 'ImageObject',
+        url: input.imageUrl,
+        width: 1200,
+        height: 1200,
+      }
+    : undefined
+
+  const author = {
+    '@type': 'Person',
+    name: 'Andrew Whited',
+    url: SITE_URL,
+  }
+
+  const publisher = {
+    '@type': 'Organization',
+    name: 'Andrew Whited Studio',
+    url: STUDIO_URL,
+  }
 
   return {
     '@context': 'https://schema.org',
-    '@type': articleType,
+    '@type': 'Article',
     headline: input.title,
     name: input.title,
     description: input.description,
-    image: input.imageUrl,
+    ...(image && { image }),
     url: `${SITE_URL}/${input.slug}`,
-    author: {
-      '@type': 'Person',
-      name: 'Andrew Whited',
-      url: SITE_URL,
-    },
-    creator: {
-      '@type': 'Person',
-      name: 'Andrew Whited',
-      url: SITE_URL,
-    },
-    ...(input.datePublished && { datePublished: input.datePublished }),
+    author,
+    creator: author,
+    publisher,
+    ...(datePublished && { datePublished }),
+    dateModified,
+    articleSection: input.type === 'CaseStudy' ? 'Case Study' : 'Essay',
   }
 }

--- a/site/src/app/ux/[slug]/opengraph-image.tsx
+++ b/site/src/app/ux/[slug]/opengraph-image.tsx
@@ -3,11 +3,12 @@ import { ImageResponse } from 'next/og'
 import { getWorkBySlug, getThoughtBySlug } from '@/lib/sanity-queries'
 import { thoughts as localThoughts } from '@/components/ux/thoughts/ThoughtArticle'
 
+// 2x dimensions — see app/ux/opengraph-image.tsx for rationale.
 export const alt = 'Andrew Whited'
-export const size = { width: 1200, height: 630 }
+export const size = { width: 2400, height: 1260 }
 export const contentType = 'image/png'
 
-const LOGO_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 360"><path d="M324.318,97.077l-43.324,165.357h-45.441l-14.053-31.15h-83.618l-14.053,31.15h-45.455L35.048,97.077h40.056l24.759,118.923,57.444-118.923h44.74l57.444,118.923,24.772-118.923h40.056M324.706,96.777h-40.688l-.05.239-24.592,118.059-57.06-118.129-.082-.17h-45.117l-.082.17-57.06,118.128-24.579-118.059-.05-.239h-40.688l.098.376,43.324,165.357.059.224h45.88l.08-.177,13.974-30.973h83.231l13.974,30.973.08.177h45.867l.059-.224,43.324-165.357.099-.376h0Z" fill="#454540"/><path d="M179.683,138.064c2.862,7.108,25.493,58.009,28.002,63.649h-56.004c2.508-5.64,25.14-56.542,28.002-63.649M179.683,137.213c-.265,1.416-28.464,64.801-28.464,64.801h56.928s-28.199-63.385-28.464-64.801h0Z" fill="#454540"/></svg>`
+const LOGO_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 360"><path d="M324.318,97.077l-43.324,165.357h-45.441l-14.053-31.15h-83.618l-14.053,31.15h-45.455L35.048,97.077h40.056l24.759,118.923,57.444-118.923h44.74l57.444,118.923,24.772-118.923h40.056M324.706,96.777h-40.688l-.05.239-24.592,118.059-57.06-118.129-.082-.17h-45.117l-.082.17-57.06,118.128-24.579-118.059-.05-.239h-40.688l.098.376,43.324,165.357.059.224h45.88l.08-.177,13.974-30.973h83.231l13.974,30.973.08.177h45.867l.059-.224,43.324-165.357.099-.376h0Z" fill="#5a5a52"/><path d="M179.683,138.064c2.862,7.108,25.493,58.009,28.002,63.649h-56.004c2.508-5.64,25.14-56.542,28.002-63.649M179.683,137.213c-.265,1.416-28.464,64.801-28.464,64.801h56.928s-28.199-63.385-28.464-64.801h0Z" fill="#5a5a52"/></svg>`
 const LOGO_DATA_URL = `data:image/svg+xml;base64,${Buffer.from(LOGO_SVG).toString('base64')}`
 
 type PageMeta = { kicker: string; title: string; subtitle?: string } | null
@@ -60,7 +61,7 @@ export default async function Image({ params }: { params: { slug: string } }) {
           display: 'flex',
           flexDirection: 'column',
           justifyContent: 'space-between',
-          padding: '72px 80px',
+          padding: '144px 160px',
           position: 'relative',
           fontFamily: 'sans-serif',
         }}
@@ -68,39 +69,35 @@ export default async function Image({ params }: { params: { slug: string } }) {
         <img
           src={LOGO_DATA_URL}
           alt=""
-          width={900}
-          height={900}
-          style={{ position: 'absolute', right: -180, top: -180 }}
+          width={1800}
+          height={1800}
+          style={{ position: 'absolute', right: -360, top: -360 }}
         />
 
         <div
           style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 14,
-            fontSize: 22,
-            letterSpacing: 0.5,
+            fontSize: 44,
+            letterSpacing: 1,
             color: '#969690',
             position: 'relative',
           }}
         >
-          <img src={LOGO_DATA_URL} alt="" width={28} height={28} />
-          <span>ANDREW WHITED</span>
+          ANDREW WHITED
         </div>
 
         <div
           style={{
             display: 'flex',
             flexDirection: 'column',
-            gap: 24,
+            gap: 48,
             position: 'relative',
-            maxWidth: 980,
+            maxWidth: 1960,
           }}
         >
           <div
             style={{
-              fontSize: 18,
-              letterSpacing: 2,
+              fontSize: 36,
+              letterSpacing: 4,
               color: '#969690',
             }}
           >
@@ -108,9 +105,9 @@ export default async function Image({ params }: { params: { slug: string } }) {
           </div>
           <div
             style={{
-              fontSize: 72,
+              fontSize: 144,
               lineHeight: 1.1,
-              letterSpacing: -1.5,
+              letterSpacing: -3,
               fontWeight: 500,
               color: '#F0F0EC',
             }}
@@ -120,9 +117,9 @@ export default async function Image({ params }: { params: { slug: string } }) {
           {subtitle && (
             <div
               style={{
-                fontSize: 26,
+                fontSize: 52,
                 color: '#969690',
-                letterSpacing: 0.2,
+                letterSpacing: 0.4,
               }}
             >
               {subtitle}

--- a/site/src/app/ux/[slug]/page.tsx
+++ b/site/src/app/ux/[slug]/page.tsx
@@ -63,7 +63,7 @@ export async function generateMetadata({
         description: shareDescription,
         url: `https://ux.andrewwhited.com/${slug}`,
         type: 'article',
-        images: [{ url: `/${slug}/opengraph-image`, width: 1200, height: 630, alt: work.title }],
+        images: [{ url: `/${slug}/opengraph-image`, width: 2400, height: 1260, alt: work.title }],
       },
       twitter: {
         card: 'summary_large_image',
@@ -88,7 +88,7 @@ export async function generateMetadata({
         description: shareDescription,
         url: `https://ux.andrewwhited.com/${slug}`,
         type: 'article',
-        images: [{ url: `/${slug}/opengraph-image`, width: 1200, height: 630, alt: sanityThought.title }],
+        images: [{ url: `/${slug}/opengraph-image`, width: 2400, height: 1260, alt: sanityThought.title }],
       },
       twitter: {
         card: 'summary_large_image',
@@ -109,7 +109,7 @@ export async function generateMetadata({
         description: localThought.intro,
         url: `https://ux.andrewwhited.com/${slug}`,
         type: 'article',
-        images: [{ url: `/${slug}/opengraph-image`, width: 1200, height: 630, alt: localThought.title }],
+        images: [{ url: `/${slug}/opengraph-image`, width: 2400, height: 1260, alt: localThought.title }],
       },
       twitter: {
         card: 'summary_large_image',
@@ -140,6 +140,7 @@ export default async function UxSlugPage({
       title: work.title,
       description: work.summary,
       imageUrl: heroImageUrl,
+      year: work.year,
       type: 'CaseStudy',
     })
     return (
@@ -165,6 +166,7 @@ export default async function UxSlugPage({
       imageUrl: localThought.heroImage
         ? `https://ux.andrewwhited.com${localThought.heroImage}`
         : undefined,
+      year: localThought.context,
       type: 'Essay',
     })
     return (

--- a/site/src/app/ux/opengraph-image.tsx
+++ b/site/src/app/ux/opengraph-image.tsx
@@ -2,8 +2,9 @@
 import { ImageResponse } from 'next/og'
 import { getUxSiteSettings, getUxPage } from '@/lib/sanity-queries'
 
+// 2x dimensions for sharper rendering on retina + after platform resampling.
 export const alt = 'Andrew Whited — Senior Design Leader'
-export const size = { width: 1200, height: 630 }
+export const size = { width: 2400, height: 1260 }
 export const contentType = 'image/png'
 
 const FALLBACK_HEADLINE =
@@ -11,8 +12,10 @@ const FALLBACK_HEADLINE =
 const FALLBACK_SUBTITLE = 'AI · Enterprise Platforms · Information Architecture'
 
 // Inline SVG of the AW "W" mark, embedded as a data URL so Satori can render it
-// without a network fetch. Source: site/public/logo-bg.svg.
-const LOGO_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 360"><path d="M324.318,97.077l-43.324,165.357h-45.441l-14.053-31.15h-83.618l-14.053,31.15h-45.455L35.048,97.077h40.056l24.759,118.923,57.444-118.923h44.74l57.444,118.923,24.772-118.923h40.056M324.706,96.777h-40.688l-.05.239-24.592,118.059-57.06-118.129-.082-.17h-45.117l-.082.17-57.06,118.128-24.579-118.059-.05-.239h-40.688l.098.376,43.324,165.357.059.224h45.88l.08-.177,13.974-30.973h83.231l13.974,30.973.08.177h45.867l.059-.224,43.324-165.357.099-.376h0Z" fill="#454540"/><path d="M179.683,138.064c2.862,7.108,25.493,58.009,28.002,63.649h-56.004c2.508-5.64,25.14-56.542,28.002-63.649M179.683,137.213c-.265,1.416-28.464,64.801-28.464,64.801h56.928s-28.199-63.385-28.464-64.801h0Z" fill="#454540"/></svg>`
+// without a network fetch. Source: site/public/logo-bg.svg. Watermark fill is
+// brightened from the site's #303028/#454540 to #5a5a52 — reads as intentional
+// graphic rather than printing artifact at preview sizes.
+const LOGO_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 360"><path d="M324.318,97.077l-43.324,165.357h-45.441l-14.053-31.15h-83.618l-14.053,31.15h-45.455L35.048,97.077h40.056l24.759,118.923,57.444-118.923h44.74l57.444,118.923,24.772-118.923h40.056M324.706,96.777h-40.688l-.05.239-24.592,118.059-57.06-118.129-.082-.17h-45.117l-.082.17-57.06,118.128-24.579-118.059-.05-.239h-40.688l.098.376,43.324,165.357.059.224h45.88l.08-.177,13.974-30.973h83.231l13.974,30.973.08.177h45.867l.059-.224,43.324-165.357.099-.376h0Z" fill="#5a5a52"/><path d="M179.683,138.064c2.862,7.108,25.493,58.009,28.002,63.649h-56.004c2.508-5.64,25.14-56.542,28.002-63.649M179.683,137.213c-.265,1.416-28.464,64.801-28.464,64.801h56.928s-28.199-63.385-28.464-64.801h0Z" fill="#5a5a52"/></svg>`
 const LOGO_DATA_URL = `data:image/svg+xml;base64,${Buffer.from(LOGO_SVG).toString('base64')}`
 
 export default async function Image() {
@@ -35,39 +38,34 @@ export default async function Image() {
           display: 'flex',
           flexDirection: 'column',
           justifyContent: 'space-between',
-          padding: '72px 80px',
+          padding: '144px 160px',
           position: 'relative',
           fontFamily: 'sans-serif',
         }}
       >
-        {/* AW outline watermark — large, low-contrast, off-center to bleed off the right edge */}
+        {/* AW outline watermark — large, off-center to bleed off the right edge */}
         <img
           src={LOGO_DATA_URL}
           alt=""
-          width={900}
-          height={900}
+          width={1800}
+          height={1800}
           style={{
             position: 'absolute',
-            right: -180,
-            top: -180,
-            opacity: 1,
+            right: -360,
+            top: -360,
           }}
         />
 
-        {/* Top: small monogram */}
+        {/* Top kicker */}
         <div
           style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 14,
-            fontSize: 22,
-            letterSpacing: 0.5,
+            fontSize: 44,
+            letterSpacing: 1,
             color: '#969690',
             position: 'relative',
           }}
         >
-          <img src={LOGO_DATA_URL} alt="" width={28} height={28} />
-          <span>ANDREW WHITED</span>
+          ANDREW WHITED
         </div>
 
         {/* Bottom: headline + subtitle */}
@@ -75,16 +73,16 @@ export default async function Image() {
           style={{
             display: 'flex',
             flexDirection: 'column',
-            gap: 28,
+            gap: 56,
             position: 'relative',
-            maxWidth: 980,
+            maxWidth: 1960,
           }}
         >
           <div
             style={{
-              fontSize: 56,
+              fontSize: 112,
               lineHeight: 1.15,
-              letterSpacing: -1,
+              letterSpacing: -2,
               fontWeight: 500,
               color: '#F0F0EC',
             }}
@@ -93,8 +91,8 @@ export default async function Image() {
           </div>
           <div
             style={{
-              fontSize: 24,
-              letterSpacing: 0.3,
+              fontSize: 48,
+              letterSpacing: 0.6,
               color: '#969690',
             }}
           >

--- a/site/src/app/ux/page.tsx
+++ b/site/src/app/ux/page.tsx
@@ -15,7 +15,7 @@ import { buildPersonSchema } from './person-schema'
 export const metadata: Metadata = {
   openGraph: {
     images: [
-      { url: '/opengraph-image', width: 1200, height: 630, alt: 'Andrew Whited — Senior Design Leader' },
+      { url: '/opengraph-image', width: 2400, height: 1260, alt: 'Andrew Whited — Senior Design Leader' },
     ],
   },
   twitter: {

--- a/site/src/app/ux/person-schema.ts
+++ b/site/src/app/ux/person-schema.ts
@@ -74,6 +74,8 @@ export function buildPersonSchema(
       ? settings.personSameAs
       : FALLBACK.sameAs
 
+  // Bare Person — simpler signal for AI tools / recruiter bots. ProfilePage
+  // would add a Google rich-snippet wrapper, but that's not the audience here.
   return {
     '@context': 'https://schema.org',
     '@type': 'Person',


### PR DESCRIPTION
## Summary

Three SEO tweaks following the initial AI/SEO pass:

- **Article schema** (case study + thought pages): switched from `CreativeWork` to `Article` — Article is a Google rich-result type, CreativeWork isn't. Added `ImageObject`, `datePublished` (derived from CMS year), and `publisher`.
- **OG image at 2x** (2400×1260): sharper on retina and after platform downsampling on LinkedIn / iMessage / etc. Watermark color brightened from `#454540` → `#5a5a52` so it reads as intentional graphic, not printing artifact. Dropped the small kicker monogram that didn't antialias well at 56px.
- **Homepage Person schema** stays as bare `Person` — flatter signal for AI recruiter bots (the actual audience), no ProfilePage wrapper.

## Test plan

- [ ] LinkedIn Post Inspector on the homepage URL — confirm sharper OG preview
- [ ] Google Rich Results Test on a case study URL (e.g. `/instana-ai-strategy`) — should now detect Article schema
- [ ] validator.schema.org on homepage — Person should validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)