### PR TITLE
Add contact email to footer + Person JSON-LD

### DIFF
--- a/sanity/schemaTypes/uxPage.js
+++ b/sanity/schemaTypes/uxPage.js
@@ -116,6 +116,12 @@ export default defineType({
       type: 'url',
     }),
     defineField({
+      name: 'contactEmail',
+      title: 'Contact email',
+      description: 'Shown in the closing footer as a mailto: link and added to the Person JSON-LD.',
+      type: 'string',
+    }),
+    defineField({
       name: 'resumeFile',
       title: 'Resume PDF',
       type: 'file',

--- a/site/src/app/ux/page.tsx
+++ b/site/src/app/ux/page.tsx
@@ -35,7 +35,7 @@ export default async function UxHome() {
     ? urlFor(page.image).width(800).quality(80).auto('format').url()
     : undefined
 
-  const personSchema = buildPersonSchema(settings, portraitUrl)
+  const personSchema = buildPersonSchema(settings, portraitUrl, page?.contactEmail)
 
   // Resume is served from /resume.pdf — a stable URL that proxies to the
   // current Sanity asset. See app/resume.pdf/route.ts.
@@ -62,6 +62,7 @@ export default async function UxHome() {
       <Thoughts items={thoughts} />
       <Links
         footerCopy={page?.footerCopy}
+        email={page?.contactEmail}
         linkedinUrl={page?.linkedinUrl}
         resumeUrl="/resume.pdf"
         studioUrl={page?.studioUrl}

--- a/site/src/app/ux/person-schema.ts
+++ b/site/src/app/ux/person-schema.ts
@@ -52,6 +52,7 @@ type Settings = {
 export function buildPersonSchema(
   settings: Settings | null,
   portraitUrl?: string,
+  email?: string,
 ) {
   const description = settings?.personDescription || FALLBACK.description
   const jobTitle = settings?.personJobTitle || FALLBACK.jobTitle
@@ -84,6 +85,7 @@ export function buildPersonSchema(
     image: portraitUrl || PORTRAIT_FALLBACK,
     jobTitle,
     description,
+    ...(email && { email: `mailto:${email}` }),
     address: {
       '@type': 'PostalAddress',
       addressLocality: address.locality,

--- a/site/src/components/ux/sections/Links.tsx
+++ b/site/src/components/ux/sections/Links.tsx
@@ -57,18 +57,44 @@ function AliasFileIcon() {
   )
 }
 
+function EmailFileIcon() {
+  return (
+    <svg
+      width="28"
+      height="34"
+      viewBox="0 0 12 15"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      className={styles.ctaFileIcon}
+    >
+      <path d="M1 1H7.5L11 4.5V14H1V1Z" stroke="currentColor" strokeWidth="1" strokeLinejoin="round" />
+      <path d="M7.5 1V4.5H11" stroke="currentColor" strokeWidth="1" strokeLinejoin="round" />
+      <rect x="3" y="8" width="6" height="4" stroke="currentColor" strokeWidth="0.85" />
+      <path d="M3 8L6 10.5L9 8" stroke="currentColor" strokeWidth="0.85" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
 type Props = {
   footerCopy?: string
+  email?: string
   linkedinUrl?: string
   resumeUrl?: string
   studioUrl?: string
 }
 
-export default function ClosingCta({ footerCopy, linkedinUrl, resumeUrl, studioUrl }: Props) {
+export default function ClosingCta({ footerCopy, email, linkedinUrl, resumeUrl, studioUrl }: Props) {
   return (
     <footer className={styles.cta}>
       <p className={styles.ctaText}>{footerCopy || 'Find me elsewhere'}</p>
       <div className={styles.ctaLinks}>
+        {email && (
+          <a href={`mailto:${email}`} className={`${styles.label} ${styles.ctaFileLink}`}>
+            <EmailFileIcon />
+            email
+          </a>
+        )}
         <a
           href={linkedinUrl || 'https://linkedin.com/in/andrewwhited'}
           className={`${styles.label} ${styles.ctaFileLink}`}


### PR DESCRIPTION
## Summary

- New `uxPage.contactEmail` Sanity field
- Envelope file-icon variant + `mailto:` link in the closing footer, positioned first in the row (email · linkedin · resume.pdf · studio)
- Person JSON-LD gets `email: mailto:<addr>` when the field is set — recruiter bots see a structured contact path

## Test plan

- [ ] Restart Sanity studio, fill `Contact email` field on UX Page
- [ ] Check footer renders the new envelope icon + "email" label
- [ ] Verify `mailto:` opens default mail client
- [ ] Curl homepage, confirm `email` appears in Person JSON-LD

🤖 Generated with [Claude Code](https://claude.com/claude-code)